### PR TITLE
Output UTC time to be able to better trace when what happened

### DIFF
--- a/source/TentaclePing/Program.cs
+++ b/source/TentaclePing/Program.cs
@@ -74,6 +74,7 @@ namespace TentaclePing
                 try
                 {
                     Console.ForegroundColor = ConsoleColor.Gray;
+                    Console.Write($"{DateTime.UtcNow:s} ");
                     Console.Write("Connect: ");
                     Console.ResetColor();
 

--- a/source/TentaclePong/Program.cs
+++ b/source/TentaclePong/Program.cs
@@ -75,7 +75,7 @@ namespace TentaclePong
                         Accept();
                     }
 
-                    Console.WriteLine("Accepted TCP client " + client.Client.RemoteEndPoint);
+                    Console.WriteLine($"{DateTime.UtcNow:s} Accepted TCP client " + client.Client.RemoteEndPoint);
                     ExecuteRequest(client);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Outputting the UTC time. While investigating https://github.com/OctopusDeploy/Halibut/issues/41 I'm running this tool and noticed that, since it'll need to run for hours unattended, the logs might show that it failed but lose the easy insight to pinpoint what happened when.

Using UTC because, in our example, we run this tool over 3 different timezones.