### PR TITLE
Upgraded to .NET Framework 4.7.2 and added SSL Protocol argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,7 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+*.lock
+*.ide
+*.ide-shm
+*.ide-wal

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Unlike regular Ping, TentaclePing makes an SSL connection to the Tentacle servic
 
 The command takes four arguments:
 
-    TentaclePing <ip/hostname> [<port>] [<datasize>] [<chunksize>]
+    TentaclePing <ip/hostname> [<port>] [<datasize>] [<chunksize>] [<ssl_protocol> {None|Ssl2|Ssl3|Tls|Tls11|Tls12|Default}]
     
 Examples:
 
-    TentaclePing.exe MyServer         # Uses default port (10933)
-    TentaclePing.exe 10.0.0.1 10934   # Explicit port
+    TentaclePing.exe MyServer                   # Uses default port (10933)
+    TentaclePing.exe 10.0.0.1 10934             # Explicit port
+    TentaclePing.exe 10.0.0.1 10933 0 2 Tls12   # Specified IP address, port, data size, chunk size, and SSL Protocol
 
 If you are experiencing slow deployments or package uploads with Octopus, you can use TentaclePing to determine whether there is a connectivity problem:
 

--- a/source/TentaclePing/TentaclePing.csproj
+++ b/source/TentaclePing/TentaclePing.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TentaclePing</RootNamespace>
     <AssemblyName>TentaclePing</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -21,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -30,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -43,6 +46,9 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/source/TentaclePing/app.config
+++ b/source/TentaclePing/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>


### PR DESCRIPTION
1) Upgraded TentaclePing project to .NET Framework 4.7.2.
2) Added a fifth argument to allow specifying SSL Protocol to use when pinging a Tentacle. Upgrading to 4.7.2 allows for expanded SSL/TLS protocol support.